### PR TITLE
Fix: Animação da morte de jogador

### DIFF
--- a/main.c
+++ b/main.c
@@ -635,8 +635,6 @@ void AnimacaoJogadorParado(Jogador *jogador, Personagem *personagem, float delta
             jogador->vida = -1;
         }
     } 
-        }
-    } 
     else if (jogador->vida == -1) //Caída
     {
         updateplayer = 0;
@@ -765,8 +763,11 @@ void UpdatePoder(Poder *imune_19, Jogador *jogador, EnvItem *envItems, int envIt
 
 void UpdateCameraCenter(Camera2D *camera, Jogador *jogador, EnvItem *envItems, int envItemsLength, float delta, int width, int height)
 {
-    camera->offset = (Vector2){width / 2, height / 2};
-    camera->target = jogador->posicao;
+    if (jogador->vida > 0)
+    {
+        camera->offset = (Vector2){width / 2, height / 2};
+        camera->target = jogador->posicao;
+    }
 }
 
 /*


### PR DESCRIPTION
### Sumário

#### Principais Commits:
268b7d2 fix: jogador perde vida infinita depois de morto
18b0636 fix: animação de morte do jogador
a9d6e49 feat: câmera deixa de acompanhar jogador morto

Constitui-se de uma PR que visa consertar a animação de morte do jogador no cenário.

### Descrição das mudanças

- O jogador deixa de perder vida infinita, para perder apenas uma unidade de vida quando morre:

https://github.com/SteffanoP/projeto-daquele-grupo/blob/a9d6e498db994147250ef2abcb32aa74bcad00c0/main.c#L476

- Câmera deixa de se mover após a morte do personagem
- Método de animação de morte mudou só um pouquinho:

https://github.com/SteffanoP/projeto-daquele-grupo/blob/a9d6e498db994147250ef2abcb32aa74bcad00c0/main.c#L626-L645

Agora a morte é fatal e quando o personagem vai para o solo, sua morte é setada como `-1`

### Possíveis desvantagens

Se houver alguma plataforma acima do personagem no momento de sua morte, pode ser que aconteça coisas inesperadas.