### PR TITLE
Fix: Colisão com bordas superiores

### DIFF
--- a/main.c
+++ b/main.c
@@ -115,7 +115,7 @@ void AnimacaoJogadorParado(Jogador *jogador, Personagem *personagem, float delta
 void Draw(Camera2D camera, EnvItem *envItems, int envItemsLength, int tamanhoInimigo, Inimigo *inimigo, Minions *minions, Gados *gados, Jogador *jogador, Personagem *personagem);
 void UpdateCameraCenter(Camera2D *camera, Jogador *jogador, EnvItem *envItems, int envItemsLength, float delta, int width, int height);
 int VerificaColisaoBordasED(Vector2 entidade, float tamanho_entidade_x, float tamanho_entidade_y, Rectangle objeto);
-bool VerificaColisaoBordaS(Vector2 entidade, float tamanho_entidade_x, float tamanho_entidade_y, Rectangle objeto);
+bool VerificaColisaoBordaS(Vector2 entidade, float tamanho_entidade_x, float tamanho_entidade_y, Rectangle objeto, int range);
 int VerificaRangeGado(Vector2 posicao_inicial, float tamanho_gado_x, float tamanho_gado_y, Rectangle jogador, float range);
 
 int main()
@@ -336,7 +336,7 @@ void UpdatePlayer(Jogador *jogador, EnvItem *envItems, int envItemsLength, float
         //Condição de colisão em objetos Universais
         if (objeto->colisao)
         {
-            if (VerificaColisaoBordaS(jogador->posicao, TAMANHO_X_JOGADOR, TAMANHO_Y_JOGADOR, objeto->retangulo))
+            if (VerificaColisaoBordaS(jogador->posicao, TAMANHO_X_JOGADOR, TAMANHO_Y_JOGADOR, objeto->retangulo, 5))
             {
                 jogador->posicao.y = objeto->retangulo.y + objeto->retangulo.height + TAMANHO_Y_JOGADOR + 1;
                 jogador->velocidade = GRAVIDADE * delta;
@@ -473,7 +473,7 @@ void UpdateInimigo(Inimigo *inimigo, EnvItem *envItems, Jogador *jogador, int ta
             jogador->vida -= 1; //Jogador encosta em inimigo e perde vida
         }
         //Verifica se borda superior do inimigo encosta em objeto jogador
-        else if (VerificaColisaoBordaS(inimigo->posicao, TAMANHO_MINION_X, TAMANHO_MINION_Y, ret_jogador))
+        else if (VerificaColisaoBordaS(inimigo->posicao, TAMANHO_MINION_X, TAMANHO_MINION_Y, ret_jogador, 5))
         {
             inimigo->tipo = 0; //Jogador mata o inimigo
         }
@@ -795,6 +795,7 @@ Verifica se há colisão com a borda superior de uma Entidade com um objeto
 Retorna 0 se não há colisão
 Retorna 1 se há colisão com borda superior
 */
+bool VerificaColisaoBordaS(Vector2 entidade, float tamanho_entidade_x, float tamanho_entidade_y, Rectangle objeto, int range) {
     const float ponto_superior = entidade.y - tamanho_entidade_y - 1;
     const float ponto_esquerda = entidade.x - (tamanho_entidade_x / 2) + range;
     const float ponto_direita = entidade.x + (tamanho_entidade_x / 2) - range;
@@ -805,8 +806,6 @@ Retorna 1 se há colisão com borda superior
         if (CheckCollisionPointRec((Vector2){ponto,ponto_superior},objeto))
         {
             return 1;
-        }
-    } 
         }
     }
 


### PR DESCRIPTION
### Sumário

#### Principais Commits:
ef6ce0d fix: colisão superior é feito com método de reta
4f81a3f feat: colisão superior possui um range para reta

Constitui-se de uma PR que visa consertar a implementação da borda superior, vista em #5, que verifica a colisão com dois pontos superiores; porém há um problema quando o hitbox do objeto é menor que a distância entre os dois pontos, observe o exemplo:

![Figura que representa a problemática da implementação #5](https://user-images.githubusercontent.com/26782009/108440664-52527900-7232-11eb-8995-593e4b66507f.png)

Observe que com a metodologia de verificação de borda superior da #5, não é possível detectar esse tipo de objeto.

### Descrição das mudanças

- O método de colisão é realizado com o método de colisão entre reta e objeto, conforme aplicado nas bordas laterais em #5. 

Logo a colisão é feita dos infinitos pontos entre o ponto da esquerdo (em amarelo) ao ponto da direita (em marrom), que se trata da reta superior (em vermelho).

![Figura que explicita a implementação da colisão entre reta e objeto](https://user-images.githubusercontent.com/26782009/108441179-5b901580-7233-11eb-87ba-1e0c362e6a72.png)

- Foi implantado um range (representado por `R`) do tamanho dessa reta, esse range é determinado pela distância do:
  - ponto inicial da entidade ao ponto inicial da reta que detecta colisão (em vermelho) e do
  - ponto final da reta que detecta colisão (em vermelho) ao ponto final da entidade
 
![Figura que explicita as delimitações dos ranges](https://user-images.githubusercontent.com/26782009/108442234-75325c80-7235-11eb-9868-c74bf80ab11e.png)

### Possíveis desvantagens

Ainda não constatados.